### PR TITLE
MOB-113 | Expose auth provider name for analytics

### DIFF
--- a/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
+++ b/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
@@ -30,6 +30,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.material.snackbar.Snackbar;
 import androidx.appcompat.app.AppCompatActivity;
+
+import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.CheckBox;
@@ -283,6 +285,11 @@ public class DemoActivity extends AppCompatActivity {
     }
 
     private LockCallback callback = new AuthenticationCallback() {
+        @Override
+        public void onProviderSelected(@Nullable String providerName) {
+            Log.d("DemoActivity", "Selected provider: " + providerName);
+        }
+
         @Override
         public void onAuthentication(Credentials credentials) {
             showResult("OK > " + credentials.getAccessToken());

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
             targetSdk: 29,
             minSdk: 23,
             kotlin: '1.3.50',
-            gradlePlugin: '4.0.0-alpha02',
+            gradlePlugin: '4.0.0-alpha03',
             bintrayPlugin: '1.8.4',
             material: '1.1.0-beta01',
             appCompat: '1.1.0',

--- a/lib/src/main/java/com/auth0/android/lock/AuthenticationCallback.java
+++ b/lib/src/main/java/com/auth0/android/lock/AuthenticationCallback.java
@@ -27,6 +27,8 @@ package com.auth0.android.lock;
 import android.content.Intent;
 import android.util.Log;
 
+import androidx.annotation.Nullable;
+
 import com.auth0.android.result.Credentials;
 
 
@@ -37,6 +39,13 @@ import com.auth0.android.result.Credentials;
 public abstract class AuthenticationCallback implements LockCallback {
 
     private static final String TAG = AuthenticationCallback.class.getSimpleName();
+
+    /**
+     * Called when the user selects a provider for authentication, i.e. "google"
+     *
+     * @param providerName the internal name of the {@link com.auth0.android.provider.AuthProvider}
+     */
+    public abstract void onProviderSelected(@Nullable String providerName);
 
     /**
      * Called when the authentication flow finished successfully.
@@ -62,6 +71,9 @@ public abstract class AuthenticationCallback implements LockCallback {
             case LockEvent.RESET_PASSWORD:
             case LockEvent.SIGN_UP:
                 break;
+            case LockEvent.SELECT_PROVIDER:
+                parseProviderName(data);
+                break;
         }
     }
 
@@ -80,5 +92,12 @@ public abstract class AuthenticationCallback implements LockCallback {
 
         Log.d(TAG, "User authenticated!");
         onAuthentication(credentials);
+    }
+
+    private void parseProviderName(Intent data) {
+        String providerName = data.getStringExtra(Constants.PROVIDER_NAME_EXTRA);
+
+        Log.d(TAG, "User selected: " + providerName);
+        onProviderSelected(providerName);
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/Constants.java
+++ b/lib/src/main/java/com/auth0/android/lock/Constants.java
@@ -35,6 +35,7 @@ abstract class Constants {
     static final String SIGN_UP_ACTION = "com.auth0.android.lock.action.SignUp";
     static final String CANCELED_ACTION = "com.auth0.android.lock.action.Canceled";
     static final String INVALID_CONFIGURATION_ACTION = "com.auth0.android.lock.action.InvalidConfiguration";
+    static final String PROVIDER_SELECTED_ACTION = "com.auth0.android.lock.action.ProviderName";
 
     static final String ERROR_EXTRA = "com.auth0.android.lock.extra.Error";
     static final String ID_TOKEN_EXTRA = "com.auth0.android.lock.extra.IdToken";
@@ -44,4 +45,5 @@ abstract class Constants {
     static final String EXPIRES_IN_EXTRA = "com.auth0.android.lock.extra.ExpiresIn";
     static final String EMAIL_EXTRA = "com.auth0.android.lock.extra.Email";
     static final String USERNAME_EXTRA = "com.auth0.android.lock.extra.Username";
+    static final String PROVIDER_NAME_EXTRA = "com.auth0.android.lock.extra.ProviderName";
 }

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -141,12 +141,17 @@ public class Lock {
         filter.addAction(Constants.SIGN_UP_ACTION);
         filter.addAction(Constants.CANCELED_ACTION);
         filter.addAction(Constants.INVALID_CONFIGURATION_ACTION);
+        filter.addAction(Constants.PROVIDER_SELECTED_ACTION);
         LocalBroadcastManager.getInstance(context).registerReceiver(this.receiver, filter);
     }
 
     private void processEvent(Context context, Intent data) {
-        LocalBroadcastManager.getInstance(context).unregisterReceiver(this.receiver);
         String action = data.getAction();
+
+        if (action != null && !action.equals(Constants.PROVIDER_SELECTED_ACTION)) {
+            LocalBroadcastManager.getInstance(context).unregisterReceiver(this.receiver);
+        }
+
         switch (action) {
             case Constants.AUTHENTICATION_ACTION:
                 Log.v(TAG, "AUTHENTICATION action received in our BroadcastReceiver");
@@ -167,6 +172,10 @@ public class Lock {
             case Constants.INVALID_CONFIGURATION_ACTION:
                 Log.v(TAG, "INVALID_CONFIGURATION_ACTION action received in our BroadcastReceiver");
                 callback.onError(new LockException(data.getStringExtra(Constants.ERROR_EXTRA)));
+                break;
+            case Constants.PROVIDER_SELECTED_ACTION:
+                Log.v(TAG, "PROVIDER_SELECTED action received in our BroadcastReceiver");
+                callback.onEvent(LockEvent.SELECT_PROVIDER, data);
                 break;
         }
     }

--- a/lib/src/main/java/com/auth0/android/lock/LockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/LockActivity.java
@@ -288,6 +288,13 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
         finish();
     }
 
+    private void deliverProviderName(String name) {
+        Intent intent = new Intent(Constants.PROVIDER_SELECTED_ACTION);
+        intent.putExtra(Constants.PROVIDER_NAME_EXTRA, name);
+
+        LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
+    }
+
     private void showSuccessMessage(String message) {
         resultMessage.setBackgroundColor(ContextCompat.getColor(this, R.color.com_auth0_lock_result_message_success_background));
         resultMessage.setVisibility(View.VISIBLE);
@@ -380,6 +387,7 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
     @Subscribe
     public void onOAuthAuthenticationRequest(OAuthLoginEvent event) {
         final String connection = event.getConnection();
+        deliverProviderName(connection);
 
         if (event.useActiveFlow()) {
             lockView.showProgress(true);
@@ -437,6 +445,7 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
             return;
         }
 
+        deliverProviderName("database");
         lockView.showProgress(true);
         lastDatabaseLogin = event;
         AuthenticationAPIClient apiClient = options.getAuthenticationAPIClient();
@@ -470,6 +479,7 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
             return;
         }
 
+        deliverProviderName("database");
         AuthenticationAPIClient apiClient = options.getAuthenticationAPIClient();
         final String connection = configuration.getDatabaseConnection().getName();
         lockView.showProgress(true);

--- a/lib/src/main/java/com/auth0/android/lock/LockCallback.java
+++ b/lib/src/main/java/com/auth0/android/lock/LockCallback.java
@@ -35,6 +35,7 @@ import java.lang.annotation.RetentionPolicy;
 import static com.auth0.android.lock.LockCallback.LockEvent.AUTHENTICATION;
 import static com.auth0.android.lock.LockCallback.LockEvent.CANCELED;
 import static com.auth0.android.lock.LockCallback.LockEvent.RESET_PASSWORD;
+import static com.auth0.android.lock.LockCallback.LockEvent.SELECT_PROVIDER;
 import static com.auth0.android.lock.LockCallback.LockEvent.SIGN_UP;
 
 /**
@@ -45,13 +46,14 @@ public interface LockCallback {
      * Type of Events that Lock can notified of.
      */
     @SuppressWarnings("UnnecessaryInterfaceModifier")
-    @IntDef({CANCELED, AUTHENTICATION, SIGN_UP, RESET_PASSWORD})
+    @IntDef({CANCELED, AUTHENTICATION, SIGN_UP, RESET_PASSWORD, SELECT_PROVIDER})
     @Retention(RetentionPolicy.SOURCE)
     public @interface LockEvent {
         int CANCELED = 0;
         int AUTHENTICATION = 1;
         int SIGN_UP = 2;
         int RESET_PASSWORD = 3;
+        int SELECT_PROVIDER = 4;
     }
 
     /**

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -141,16 +141,22 @@ public class PasswordlessLock {
         filter.addAction(Constants.AUTHENTICATION_ACTION);
         filter.addAction(Constants.CANCELED_ACTION);
         filter.addAction(Constants.INVALID_CONFIGURATION_ACTION);
+        filter.addAction(Constants.PROVIDER_SELECTED_ACTION);
         LocalBroadcastManager.getInstance(context).registerReceiver(this.receiver, filter);
     }
 
     private void processEvent(Context context, Intent data) {
-        LocalBroadcastManager.getInstance(context).unregisterReceiver(this.receiver);
         if (data == null || data.getAction() == null) {
+            LocalBroadcastManager.getInstance(context).unregisterReceiver(this.receiver);
             return;
         }
 
         String action = data.getAction();
+
+        if (!action.equals(Constants.PROVIDER_SELECTED_ACTION)) {
+            LocalBroadcastManager.getInstance(context).unregisterReceiver(this.receiver);
+        }
+
         switch (action) {
             case Constants.AUTHENTICATION_ACTION:
                 Log.v(TAG, "AUTHENTICATION action received in our BroadcastReceiver");
@@ -167,6 +173,10 @@ public class PasswordlessLock {
             case Constants.INVALID_CONFIGURATION_ACTION:
                 Log.v(TAG, "INVALID_CONFIGURATION_ACTION action received in our BroadcastReceiver");
                 callback.onError(new LockException(data.getStringExtra(Constants.ERROR_EXTRA)));
+                break;
+            case Constants.PROVIDER_SELECTED_ACTION:
+                Log.v(TAG, "PROVIDER_SELECTED action received in our BroadcastReceiver");
+                callback.onEvent(LockEvent.SELECT_PROVIDER, data);
                 break;
         }
     }


### PR DESCRIPTION
Sends an event with the selected provider name each time the user attempts to login. I tried to keep with the current pattern, which is to post an intent with data to the local broadcastmanager, which then triggers the auth callback.

![image (28)](https://user-images.githubusercontent.com/11651971/70738020-b988ab00-1cc8-11ea-8916-05bde9302ab8.png)