### PR TITLE
MOB-728 | Do not assign default error description

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/errors/LoginErrorMessageBuilder.java
+++ b/lib/src/main/java/com/auth0/android/lock/errors/LoginErrorMessageBuilder.java
@@ -38,6 +38,7 @@ public class LoginErrorMessageBuilder implements ErrorMessageBuilder<Authenticat
     private static final String USER_IS_BLOCKED_DESCRIPTION = "user is blocked";
     private static final String TOO_MANY_ATTEMPTS_ERROR = "too_many_attempts";
     private static final String WRONG_CLIENT_TYPE_ERROR = "Unauthorized";
+    private static final String FORCE_PASSWORD_RESET_ERROR = "force_password_reset";
 
     private static final int userExistsResource = R.string.com_auth0_lock_db_signup_user_already_exists_error_message;
     private static final int unauthorizedResource = R.string.com_auth0_lock_db_login_error_unauthorized_message;
@@ -61,7 +62,11 @@ public class LoginErrorMessageBuilder implements ErrorMessageBuilder<Authenticat
     @Override
     public AuthenticationError buildFrom(AuthenticationException exception) {
         int messageRes;
-        String description = exception.getDescription();
+        String description = null;
+
+        if (FORCE_PASSWORD_RESET_ERROR.equals(exception.getDescription())) {
+            description = exception.getDescription();
+        }
 
         if (exception.isInvalidCredentials()) {
             messageRes = invalidCredentialsResource;


### PR DESCRIPTION
Partially reverts bce37ba. Now we only assign an error description if it matches our special force password reset case. Otherwise we leave it `null` since lock is doing nullability checks before displaying the error banner. 

Gifs to show the error banner working in default state and force password reset state:

Default:
![basic-error](https://user-images.githubusercontent.com/11651971/78186338-6fffcf80-7421-11ea-929f-2640f451bff5.gif)

Force password reset:
![force-password-reset](https://user-images.githubusercontent.com/11651971/78186328-6bd3b200-7421-11ea-8270-07165ff6e195.gif)