### PR TITLE
Fix Google Sign In Button

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -9,7 +9,6 @@
         <item name="Auth0.HeaderBackground">@color/color_background_secondary</item>
         <item name="Auth0.DarkPrimaryColor">?colorPrimary</item>
         <item name="Auth0.PrimaryColor">?colorPrimary</item>
-        <item name="Auth0.BackgroundColor">?backgroundColor</item>
         <item name="android:textColorHighlight">?colorOnPrimary</item>
         <item name="android:windowBackground">?backgroundColor</item>
         <item name="android:textColorLink">?colorPrimary</item>

--- a/lib/src/main/java/com/auth0/android/lock/views/SocialButton.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/SocialButton.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.ShapeDrawable;
 import android.graphics.drawable.StateListDrawable;
 import androidx.annotation.ColorInt;
@@ -50,13 +51,13 @@ class SocialButton extends RelativeLayout {
     }
 
     private StateListDrawable getTouchFeedbackBackground(@ColorInt int pressedColor, @ViewUtils.Corners int corners) {
-        final ShapeDrawable normalBackground;
+        final Drawable normalBackground;
         final ShapeDrawable pressedBackground;
 
         boolean shouldDrawOutline = pressedColor == Color.WHITE;
         if (shouldDrawOutline) {
             int outlineColor = getResources().getColor(R.color.com_auth0_lock_social_light_background_focused);
-            normalBackground = ViewUtils.getRoundedOutlineBackground(getResources(), outlineColor);
+            normalBackground = ViewUtils.getOpaqueRoundedOutlineBackground(getResources(), pressedColor, outlineColor);
             pressedBackground = ViewUtils.getRoundedBackground(this, outlineColor, corners);
         } else {
             normalBackground = ViewUtils.getRoundedBackground(this, pressedColor, corners);

--- a/lib/src/main/java/com/auth0/android/lock/views/ViewUtils.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ViewUtils.java
@@ -28,6 +28,7 @@ import android.content.res.ColorStateList;
 import android.content.res.Resources;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.ShapeDrawable;
 import android.graphics.drawable.shapes.RoundRectShape;
 import android.os.Build;
@@ -125,6 +126,28 @@ abstract class ViewUtils {
         RoundRectShape rr = new RoundRectShape(new float[]{r, r, r, r, r, r, r, r}, new RectF(t, t, t, t), new float[]{r, r, r, r, r, r, r, r});
         ShapeDrawable drawable = new ShapeDrawable(rr);
         drawable.getPaint().setColor(color);
+        return drawable;
+    }
+
+    /**
+     * Generates a rounded outline drawable with the given background color.
+     *
+     * @param resources the context's current resources.
+     * @param backgroundColor the color to use as background.
+     * @param outlineColor the color to use as the outline
+     * @return the rounded drawable.
+     */
+    static GradientDrawable getOpaqueRoundedOutlineBackground(
+            Resources resources,
+            @ColorInt int backgroundColor,
+            @ColorInt int outlineColor
+    ) {
+        int cornerRadius = resources.getDimensionPixelSize(R.dimen.com_auth0_lock_widget_corner_radius);
+        int stroke = resources.getDimensionPixelSize(R.dimen.com_auth0_lock_input_field_stroke_width);
+        GradientDrawable drawable = new GradientDrawable();
+        drawable.setCornerRadius(cornerRadius);
+        drawable.setColor(backgroundColor);
+        drawable.setStroke(stroke, outlineColor);
         return drawable;
     }
 


### PR DESCRIPTION
This bug was introduced with [v2.18.0 of Lock.Android](https://github.com/auth0/Lock.Android/pull/563). There is special logic to create an outlined button background when the color is `#FFFFFF`. The outlined background is transparent, so in dark mode the Google sign in button is broken:
![google-sign-in](https://user-images.githubusercontent.com/11651971/85047370-8ecf5180-b146-11ea-8aaa-2b97348ad896.png)

I created a new method that makes an opaque background with an outline. I did not modify the existing method because it is used elsewhere to create outlined input views. 

Fixed button:
![google-login-fixed](https://user-images.githubusercontent.com/11651971/85047567-df46af00-b146-11ea-9316-c234417b4f03.png)


